### PR TITLE
solved BAD_EXEC_ACCESS on [readStream open] or [writeStream open]

### DIFF
--- a/GoldRaccoon/Sources/Utils/GRStreamInfo.m
+++ b/GoldRaccoon/Sources/Utils/GRStreamInfo.m
@@ -49,6 +49,9 @@
     
     // a little bit of C because I was not able to make NSInputStream play nice
     CFReadStreamRef readStreamRef = CFReadStreamCreateWithFTPURL(NULL, ( __bridge CFURLRef) request.fullURL);
+    CFReadStreamSetProperty(readStreamRef,
+                            kCFStreamPropertyFTPAttemptPersistentConnection,
+                            kCFBooleanFalse);
     
     CFReadStreamSetProperty(readStreamRef, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanTrue);
 	CFReadStreamSetProperty(readStreamRef, kCFStreamPropertyFTPUsePassiveMode, request.passiveMode ? kCFBooleanTrue :kCFBooleanFalse);
@@ -91,6 +94,9 @@
     }
     
     CFWriteStreamRef writeStreamRef = CFWriteStreamCreateWithFTPURL(NULL, ( __bridge CFURLRef) request.fullURL);
+    CFWriteStreamSetProperty(writeStreamRef,
+                             kCFStreamPropertyFTPAttemptPersistentConnection,
+                             kCFBooleanFalse);
     
     CFWriteStreamSetProperty(writeStreamRef, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanTrue);
 	CFWriteStreamSetProperty(writeStreamRef, kCFStreamPropertyFTPUsePassiveMode, request.passiveMode ? kCFBooleanTrue :kCFBooleanFalse);


### PR DESCRIPTION
I solved issue #4.

I referred this site.
http://stackoverflow.com/questions/20111643/exc-bad-access-sigsegv-when-uploading-with-ftp-library-on-ios-cfwritestreamop

Best regards.
