### PR TITLE
upload file to path needs escape

### DIFF
--- a/GoldRaccoon/Sources/Requests/GRUploadRequest.m
+++ b/GoldRaccoon/Sources/Requests/GRUploadRequest.m
@@ -30,6 +30,11 @@
 @synthesize localFilePath = _localFilePath;
 @synthesize fullRemotePath = _fullRemotePath;
 
+- (NSString *)rawPath
+{
+    return _path;
+}
+
 - (void)start
 {
     self.maximumSize = LONG_MAX;
@@ -44,7 +49,7 @@
     // we first list the directory to see if our folder is up on the server
     self.listingRequest = [[GRListingRequest alloc] initWithDelegate:self datasource:self];
 	self.listingRequest.passiveMode = self.passiveMode;
-    self.listingRequest.path = [self.path stringByDeletingLastPathComponent];
+    self.listingRequest.path = [[self rawPath] stringByDeletingLastPathComponent];
     [self.listingRequest start];
 }
 


### PR DESCRIPTION
Hi @albertodebortoli

I solved a problem.

When upload file to path needs escape, like '/test(folder)/', next error occured.

'File or directory not available or directory already exists.'

When upload, GoldRaccoon first list the directory.
But set path for ListingRequest is escaped path.
And when ListingRequest started, ListingRequest escape the path again.

I change to set raw path for ListingRequest when upload.

Best regards.
