### PR TITLE
Fixed problem where path was escaped multiple times

### DIFF
--- a/GoldRaccoon/Sources/Requests/GRCreateDirectoryRequest.m
+++ b/GoldRaccoon/Sources/Requests/GRCreateDirectoryRequest.m
@@ -47,7 +47,7 @@
     
     // we first list the directory to see if our folder is up already
     self.listrequest = [[GRListingRequest alloc] initWithDelegate:self datasource:self];
-    self.listrequest.path = [self.path stringByDeletingLastPathComponent];
+    self.listrequest.path = self.dirname;
     [self.listrequest start];
 }
 

--- a/GoldRaccoon/Sources/Requests/GRRequest.h
+++ b/GoldRaccoon/Sources/Requests/GRRequest.h
@@ -34,6 +34,8 @@
 @property (nonatomic, assign) BOOL didOpenStream;               // whether the stream opened or not
 @property (nonatomic, assign) BOOL cancelDoesNotCallDelegate;   // cancel closes stream without calling delegate
 
+@property (nonatomic, readonly) NSString *dirname;
+
 - (instancetype)initWithDelegate:(id<GRRequestDelegate>)aDelegate datasource:(id<GRRequestDataSource>)aDatasource;
 
 @end

--- a/GoldRaccoon/Sources/Requests/GRRequest.m
+++ b/GoldRaccoon/Sources/Requests/GRRequest.m
@@ -157,4 +157,8 @@
     self.streamInfo.cancelDoesNotCallDelegate = cancelDoesNotCallDelegate;
 }
 
+- (NSString *)dirname {
+    return [_path stringByDeletingLastPathComponent];
+}
+
 @end

--- a/GoldRaccoon/Sources/Requests/GRUploadRequest.m
+++ b/GoldRaccoon/Sources/Requests/GRUploadRequest.m
@@ -44,7 +44,7 @@
     // we first list the directory to see if our folder is up on the server
     self.listingRequest = [[GRListingRequest alloc] initWithDelegate:self datasource:self];
 	self.listingRequest.passiveMode = self.passiveMode;
-    self.listingRequest.path = [self.path stringByDeletingLastPathComponent];
+    self.listingRequest.path = self.dirname;
     [self.listingRequest start];
 }
 


### PR DESCRIPTION
This pull requests fixes problem where create directory and upload requests would not work if path contained characters that need escaping.

Problem is in the code below that uses `self.path` which is already escaped to set up listing request which escapes is for the second time:

``` objective-c
self.listrequest = [[GRListingRequest alloc] initWithDelegate:self datasource:self];
self.listrequest.path = [self.path stringByDeletingLastPathComponent];
```
